### PR TITLE
Add ResearchHubVoting approval-only issuance voting

### DIFF
--- a/script/ResearchHubVotingDeployer.s.sol
+++ b/script/ResearchHubVotingDeployer.s.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.25;
+
+import {Script, console} from "forge-std/Script.sol";
+import {StakeToken} from "../src/StakeToken.sol";
+import {ResearchHubVoting} from "../src/ResearchHubVoting.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+
+/// @notice Deploys `ResearchHubVoting` behind an ERC1967 (UUPS) proxy.
+/// @dev Required env:
+///      - OWNER        : owner of the voting contract (admin + UUPS upgrades)
+///      - VOTE_TOKEN   : sSOSO StakeToken address used to lock voting power
+///      Optional env:
+///      - ISSUER       : address to authorize as issuer (default: skip)
+///      - GRANT_LOCKER : grant the voting contract the locker role on VOTE_TOKEN (default: true).
+///                       Requires the broadcaster to be the StakeToken owner.
+contract ResearchHubVotingDeployerScript is Script {
+    function setUp() public {}
+
+    function run() public {
+        address owner = vm.envAddress("OWNER");
+        address voteToken = vm.envAddress("VOTE_TOKEN");
+        address issuer = vm.envOr("ISSUER", address(0));
+        bool grantLocker = vm.envOr("GRANT_LOCKER", true);
+
+        vm.startBroadcast();
+
+        ResearchHubVoting votingImpl = new ResearchHubVoting();
+        address voting = address(new ERC1967Proxy(
+            address(votingImpl),
+            abi.encodeCall(ResearchHubVoting.initialize, (voteToken, owner))
+        ));
+
+        // Let the voting contract lock/unlock voting power on the StakeToken.
+        if (grantLocker) {
+            try StakeToken(payable(voteToken)).grantLockerRole(voting) {} catch {}
+        }
+        // Optionally authorize an initial issuer (only succeeds if broadcaster == owner).
+        if (issuer != address(0)) {
+            try ResearchHubVoting(voting).grantIssuerRole(issuer) {} catch {}
+        }
+
+        vm.stopBroadcast();
+
+        console.log(string.concat("votingImpl=", vm.toString(address(votingImpl))));
+        console.log(string.concat("voting=", vm.toString(voting)));
+        console.log(string.concat("voteToken=", vm.toString(voteToken)));
+        console.log(string.concat("votingIsLocker=", vm.toString(StakeToken(payable(voteToken)).lockers(voting))));
+        if (issuer != address(0)) {
+            console.log(string.concat("issuerAuthorized=", vm.toString(ResearchHubVoting(voting).issuers(issuer))));
+        }
+    }
+}

--- a/src/Interface.sol
+++ b/src/Interface.sol
@@ -198,5 +198,7 @@ interface IAssetFeeManager is IAssetController {
 
 interface ILockable {
     function lock(address user, uint256 amount, uint256 expiry) external;
+    function lock(address user, uint256 amount) external;
+    function unlock(address user, uint256 amount) external;
     function getAvailableBalance(address user) external view returns (uint256);
 }

--- a/src/ResearchHubVoting.sol
+++ b/src/ResearchHubVoting.sol
@@ -161,11 +161,26 @@ contract ResearchHubVoting is Initializable, OwnableUpgradeable, UUPSUpgradeable
     /// @dev Caller must be an authorized issuer (`grantIssuerRole`).
     /// @param proposalId Proposal id to create (must not already exist).
     function createProposal(uint256 proposalId) external onlyIssuer whenNotPaused {
+        _createProposal(proposalId, msg.sender);
+    }
+
+    /// @notice Creates multiple asset issuance proposals in one call. The caller becomes the
+    ///         issuer of each. Reverts (and creates none) if any id already exists.
+    /// @dev Caller must be an authorized issuer (`grantIssuerRole`).
+    /// @param proposalIds Proposal ids to create (each must not already exist).
+    function batchCreateProposal(uint256[] calldata proposalIds) external onlyIssuer whenNotPaused {
+        for (uint256 i; i < proposalIds.length; i++) {
+            _createProposal(proposalIds[i], msg.sender);
+        }
+    }
+
+    /// @dev Creates a proposal with `issuer` as creator.
+    function _createProposal(uint256 proposalId, address issuer) internal {
         Proposal storage proposal = proposals[proposalId];
         if (proposal.state != ProposalState.NonExistent) revert ProposalAlreadyExists(proposalId);
-        proposal.issuer = msg.sender;
+        proposal.issuer = issuer;
         proposal.state = ProposalState.Voting;
-        emit ProposalCreated(proposalId, msg.sender);
+        emit ProposalCreated(proposalId, issuer);
     }
 
     /// @notice Casts (or adds to) an approve vote by locking `amount` of voting power.

--- a/src/ResearchHubVoting.sol
+++ b/src/ResearchHubVoting.sol
@@ -94,6 +94,7 @@ contract ResearchHubVoting is Initializable, OwnableUpgradeable, UUPSUpgradeable
     error ExceedsVotedAmount(uint256 proposalId, address voter, uint256 voted, uint256 requested);
     error ExpiredSignature(uint256 deadline);
     error InvalidNonce(address signer, uint256 expected, uint256 provided);
+    error InvalidRange(uint256 begin, uint256 end);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -320,6 +321,35 @@ contract ResearchHubVoting is Initializable, OwnableUpgradeable, UUPSUpgradeable
         votedAmounts = new uint256[](len);
         for (uint256 i; i < len; i++) {
             uint256 pid = proposalIds[i];
+            proposalInfos[i] = proposals[pid];
+            votedAmounts[i] = votes[pid][voter];
+        }
+    }
+
+    /// @notice Paginated variant of `getParticipatedProposals`: returns the `[begin, end)`
+    ///         slice of `voter`'s participated proposals with each proposal's current record
+    ///         and the voter's current vote amount.
+    /// @param voter Voter address.
+    /// @param begin Start index (inclusive) in the voter's participation list.
+    /// @param end End index (exclusive); must satisfy `begin < end <= getParticipatedCount(voter)`.
+    /// @return proposalIds Proposal ids in the requested range.
+    /// @return proposalInfos Current proposal records, aligned with `proposalIds`.
+    /// @return votedAmounts Voter's current vote amount per proposal, aligned with `proposalIds`.
+    function getParticipatedProposals(address voter, uint256 begin, uint256 end)
+        external
+        view
+        returns (uint256[] memory proposalIds, Proposal[] memory proposalInfos, uint256[] memory votedAmounts)
+    {
+        uint256[] storage all = _participated[voter];
+        if (begin >= end || end > all.length) revert InvalidRange(begin, end);
+
+        uint256 len = end - begin;
+        proposalIds = new uint256[](len);
+        proposalInfos = new Proposal[](len);
+        votedAmounts = new uint256[](len);
+        for (uint256 i; i < len; i++) {
+            uint256 pid = all[begin + i];
+            proposalIds[i] = pid;
             proposalInfos[i] = proposals[pid];
             votedAmounts[i] = votes[pid][voter];
         }

--- a/src/ResearchHubVoting.sol
+++ b/src/ResearchHubVoting.sol
@@ -1,0 +1,223 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.25;
+
+import {ILockable} from "./Interface.sol";
+import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
+import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
+import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
+import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
+import {ReentrancyGuardTransientUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardTransientUpgradeable.sol";
+
+/// @title ResearchHubVoting
+/// @notice Approval-only voting for asset issuance proposals.
+///         An issuer creates a proposal; anyone votes "approve" by locking voting tokens
+///         (sSOSO `StakeToken`, via `ILockable.lock`). Voters can withdraw (unlock) their
+///         votes at any time. The issuer may end voting at any time; once ended, voters can
+///         only withdraw.
+/// @dev
+/// - Voting power is locked/released through `ILockable.lock(user, amount)` / `unlock(user, amount)`.
+///   This contract must be granted the locker role on the voting token.
+/// - On-chain bookkeeping (`voterCount`, `totalVotes`, per-voter `votes`) is a live snapshot.
+///   Authoritative per-voter weight (amount x duration) is computed off-chain from the
+///   `Voted` / `VoteWithdrawn` events (which carry block timestamps) together with the token's
+///   `BalanceLocked` / `BalanceUnlocked` events.
+contract ResearchHubVoting is Initializable, OwnableUpgradeable, UUPSUpgradeable, PausableUpgradeable, ReentrancyGuardTransientUpgradeable {
+    /// @notice Lifecycle states of a proposal.
+    enum ProposalState {
+        /// @notice Proposal does not exist (default).
+        NonExistent,
+        /// @notice Voting is open: votes can be cast or withdrawn.
+        Voting,
+        /// @notice Voting ended by the issuer: only withdrawals are allowed.
+        VotingEnded
+    }
+
+    /// @notice Proposal metadata and live voting totals.
+    struct Proposal {
+        /// @notice Creator of the proposal (the issuer); only this address can end voting.
+        address issuer;
+        /// @notice Current lifecycle state.
+        ProposalState state;
+        /// @notice Number of voters currently holding a non-zero vote (incremented on 0->positive, decremented on positive->0).
+        uint256 voterCount;
+        /// @notice Sum of all currently locked votes (decreases on withdrawal).
+        uint256 totalVotes;
+    }
+
+    /// @notice Voting token that supports balance locking (sSOSO `StakeToken`).
+    ILockable public voteToken;
+
+    /// @notice Addresses authorized to create issuance proposals.
+    mapping(address => bool) public issuers;
+
+    /// @notice Proposal id => proposal data.
+    mapping(uint256 => Proposal) public proposals;
+    /// @notice Proposal id => voter => current vote amount (also used as the "currently voting" flag).
+    mapping(uint256 => mapping(address => uint256)) public votes;
+    /// @notice Proposal id => voter => whether the voter has ever voted on this proposal.
+    /// @dev Gates the one-time `_participated` push so a voter who fully withdraws and votes
+    ///      again is not recorded twice.
+    mapping(uint256 => mapping(address => bool)) public hasVoted;
+    /// @dev Voter => list of proposal ids the voter has participated in (pushed once, on first vote).
+    mapping(address => uint256[]) private _participated;
+
+    /// @notice Emitted when a proposal is created.
+    event ProposalCreated(uint256 indexed proposalId, address indexed issuer);
+    /// @notice Emitted when a voter casts (or adds to) an approve vote, locking `amount`.
+    /// @param totalVoted The voter's resulting total vote amount on this proposal.
+    event Voted(uint256 indexed proposalId, address indexed voter, uint256 amount, uint256 totalVoted);
+    /// @notice Emitted when a voter withdraws part/all of their vote, unlocking `amount`.
+    /// @param totalVoted The voter's remaining total vote amount on this proposal.
+    event VoteWithdrawn(uint256 indexed proposalId, address indexed voter, uint256 amount, uint256 totalVoted);
+    /// @notice Emitted when the issuer ends voting.
+    event VotingEnded(uint256 indexed proposalId, address indexed issuer, uint256 totalVotes, uint256 voterCount);
+    /// @notice Emitted when an address is granted the issuer role.
+    event IssuerRoleGranted(address indexed issuer);
+    /// @notice Emitted when an address has its issuer role revoked.
+    event IssuerRoleRevoked(address indexed issuer);
+
+    error ZeroAddress();
+    error ZeroAmount();
+    error ProposalAlreadyExists(uint256 proposalId);
+    error ProposalNotVoting(uint256 proposalId);
+    error ProposalNotExist(uint256 proposalId);
+    error NotIssuer(uint256 proposalId);
+    error NotAuthorizedIssuer(address account);
+    error ExceedsVotedAmount(uint256 proposalId, address voter, uint256 voted, uint256 requested);
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
+    /// @notice Initializes the upgradeable contract.
+    /// @param voteToken_ Voting token supporting `ILockable` (must be non-zero).
+    /// @param owner_ Owner for admin controls and UUPS upgrades (must be non-zero).
+    function initialize(address voteToken_, address owner_) public initializer {
+        if (voteToken_ == address(0) || owner_ == address(0)) revert ZeroAddress();
+        __Ownable_init(owner_);
+        __UUPSUpgradeable_init();
+        __Pausable_init();
+        __ReentrancyGuardTransient_init();
+        voteToken = ILockable(voteToken_);
+    }
+
+    function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+
+    /// @notice Pauses voting, withdrawals and proposal creation.
+    function pause() external onlyOwner {
+        _pause();
+    }
+
+    /// @notice Unpauses the contract.
+    function unpause() external onlyOwner {
+        _unpause();
+    }
+
+    /// @notice Authorizes `account` to create issuance proposals.
+    function grantIssuerRole(address account) external onlyOwner {
+        if (account == address(0)) revert ZeroAddress();
+        issuers[account] = true;
+        emit IssuerRoleGranted(account);
+    }
+
+    /// @notice Revokes `account`'s authorization to create issuance proposals.
+    function revokeIssuerRole(address account) external onlyOwner {
+        issuers[account] = false;
+        emit IssuerRoleRevoked(account);
+    }
+
+    /// @notice Restricts a function to authorized issuers.
+    modifier onlyIssuer() {
+        if (!issuers[msg.sender]) revert NotAuthorizedIssuer(msg.sender);
+        _;
+    }
+
+    /// @notice Creates a new asset issuance proposal. The caller becomes the proposal issuer.
+    /// @dev Caller must be an authorized issuer (`grantIssuerRole`).
+    /// @param proposalId Proposal id to create (must not already exist).
+    function createProposal(uint256 proposalId) external onlyIssuer whenNotPaused {
+        Proposal storage proposal = proposals[proposalId];
+        if (proposal.state != ProposalState.NonExistent) revert ProposalAlreadyExists(proposalId);
+        proposal.issuer = msg.sender;
+        proposal.state = ProposalState.Voting;
+        emit ProposalCreated(proposalId, msg.sender);
+    }
+
+    /// @notice Casts (or adds to) an approve vote by locking `amount` of voting power.
+    /// @param proposalId Proposal id (must be in `Voting` state).
+    /// @param amount Voting weight to lock (must be > 0; must not exceed available balance).
+    function vote(uint256 proposalId, uint256 amount) external nonReentrant whenNotPaused {
+        Proposal storage proposal = proposals[proposalId];
+        if (proposal.state != ProposalState.Voting) revert ProposalNotVoting(proposalId);
+        if (amount == 0) revert ZeroAmount();
+
+        voteToken.lock(msg.sender, amount);
+
+        if (votes[proposalId][msg.sender] == 0) {
+            proposal.voterCount += 1;
+        }
+        if (!hasVoted[proposalId][msg.sender]) {
+            hasVoted[proposalId][msg.sender] = true;
+            _participated[msg.sender].push(proposalId);
+        }
+        votes[proposalId][msg.sender] += amount;
+        proposal.totalVotes += amount;
+
+        emit Voted(proposalId, msg.sender, amount, votes[proposalId][msg.sender]);
+    }
+
+    /// @notice Withdraws part/all of the caller's vote, unlocking `amount` of voting power.
+    /// @dev Allowed while voting is open (retract vote) and after it ends (release only).
+    /// @param proposalId Proposal id (must exist).
+    /// @param amount Amount to withdraw (must be > 0 and <= caller's current vote).
+    function withdrawVote(uint256 proposalId, uint256 amount) external nonReentrant whenNotPaused {
+        Proposal storage proposal = proposals[proposalId];
+        if (proposal.state == ProposalState.NonExistent) revert ProposalNotExist(proposalId);
+        if (amount == 0) revert ZeroAmount();
+        uint256 voted = votes[proposalId][msg.sender];
+        if (amount > voted) revert ExceedsVotedAmount(proposalId, msg.sender, voted, amount);
+
+        voteToken.unlock(msg.sender, amount);
+
+        uint256 remaining = voted - amount;
+        votes[proposalId][msg.sender] = remaining;
+        proposal.totalVotes -= amount;
+        if (remaining == 0) {
+            proposal.voterCount -= 1;
+        }
+
+        emit VoteWithdrawn(proposalId, msg.sender, amount, remaining);
+    }
+
+    /// @notice Ends voting for a proposal. Only the proposal's issuer can call.
+    /// @dev After ending, `vote` reverts but `withdrawVote` remains available.
+    /// @param proposalId Proposal id (must be in `Voting` state).
+    function endVoting(uint256 proposalId) external whenNotPaused {
+        Proposal storage proposal = proposals[proposalId];
+        if (proposal.state != ProposalState.Voting) revert ProposalNotVoting(proposalId);
+        if (msg.sender != proposal.issuer) revert NotIssuer(proposalId);
+        proposal.state = ProposalState.VotingEnded;
+        emit VotingEnded(proposalId, proposal.issuer, proposal.totalVotes, proposal.voterCount);
+    }
+
+    /// @notice Returns the full proposal record.
+    function getProposal(uint256 proposalId) external view returns (Proposal memory) {
+        return proposals[proposalId];
+    }
+
+    /// @notice Returns `voter`'s current vote amount on `proposalId`.
+    function getVotes(uint256 proposalId, address voter) external view returns (uint256) {
+        return votes[proposalId][voter];
+    }
+
+    /// @notice Returns the list of distinct proposal ids `voter` has participated in.
+    function getParticipatedProposals(address voter) external view returns (uint256[] memory) {
+        return _participated[voter];
+    }
+
+    /// @notice Returns how many participation entries `voter` has.
+    function getParticipatedCount(address voter) external view returns (uint256) {
+        return _participated[voter].length;
+    }
+}

--- a/src/ResearchHubVoting.sol
+++ b/src/ResearchHubVoting.sol
@@ -7,6 +7,9 @@ import {UUPSUpgradeable} from "@openzeppelin/contracts-upgradeable/proxy/utils/U
 import {OwnableUpgradeable} from "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import {PausableUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/PausableUpgradeable.sol";
 import {ReentrancyGuardTransientUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ReentrancyGuardTransientUpgradeable.sol";
+import {EIP712Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/cryptography/EIP712Upgradeable.sol";
+import {NoncesUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/NoncesUpgradeable.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
 
 /// @title ResearchHubVoting
 /// @notice Approval-only voting for asset issuance proposals.
@@ -21,7 +24,12 @@ import {ReentrancyGuardTransientUpgradeable} from "@openzeppelin/contracts-upgra
 ///   Authoritative per-voter weight (amount x duration) is computed off-chain from the
 ///   `Voted` / `VoteWithdrawn` events (which carry block timestamps) together with the token's
 ///   `BalanceLocked` / `BalanceUnlocked` events.
-contract ResearchHubVoting is Initializable, OwnableUpgradeable, UUPSUpgradeable, PausableUpgradeable, ReentrancyGuardTransientUpgradeable {
+contract ResearchHubVoting is Initializable, OwnableUpgradeable, UUPSUpgradeable, PausableUpgradeable, ReentrancyGuardTransientUpgradeable, EIP712Upgradeable, NoncesUpgradeable {
+    /// @dev EIP-712 typehash for `voteFor`.
+    bytes32 public constant VOTE_TYPE_HASH = keccak256("Vote(uint256 proposalId,uint256 amount,uint256 nonce,uint256 deadline)");
+    /// @dev EIP-712 typehash for `withdrawVoteFor`.
+    bytes32 public constant WITHDRAW_VOTE_TYPE_HASH = keccak256("WithdrawVote(uint256 proposalId,uint256 amount,uint256 nonce,uint256 deadline)");
+
     /// @notice Lifecycle states of a proposal.
     enum ProposalState {
         /// @notice Proposal does not exist (default).
@@ -84,6 +92,8 @@ contract ResearchHubVoting is Initializable, OwnableUpgradeable, UUPSUpgradeable
     error NotIssuer(uint256 proposalId);
     error NotAuthorizedIssuer(address account);
     error ExceedsVotedAmount(uint256 proposalId, address voter, uint256 voted, uint256 requested);
+    error ExpiredSignature(uint256 deadline);
+    error InvalidNonce(address signer, uint256 expected, uint256 provided);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -99,10 +109,24 @@ contract ResearchHubVoting is Initializable, OwnableUpgradeable, UUPSUpgradeable
         __UUPSUpgradeable_init();
         __Pausable_init();
         __ReentrancyGuardTransient_init();
+        __EIP712_init("ResearchHubVoting", "1.0.0");
+        __Nonces_init();
         voteToken = ILockable(voteToken_);
     }
 
     function _authorizeUpgrade(address newImplementation) internal override onlyOwner {}
+
+    /// @dev Verifies an EIP-712 meta-tx signature, deadline and nonce; consumes the signer's nonce.
+    function _verifyAndConsumeMetaTx(bytes32 digest, uint256 nonce, uint256 deadline, bytes calldata signature)
+        internal
+        returns (address signer)
+    {
+        if (deadline < block.timestamp) revert ExpiredSignature(deadline);
+        signer = ECDSA.recover(digest, signature);
+        uint256 expectedNonce = nonces(signer);
+        if (nonce != expectedNonce) revert InvalidNonce(signer, expectedNonce, nonce);
+        _useNonce(signer);
+    }
 
     /// @notice Pauses voting, withdrawals and proposal creation.
     function pause() external onlyOwner {
@@ -148,23 +172,44 @@ contract ResearchHubVoting is Initializable, OwnableUpgradeable, UUPSUpgradeable
     /// @param proposalId Proposal id (must be in `Voting` state).
     /// @param amount Voting weight to lock (must be > 0; must not exceed available balance).
     function vote(uint256 proposalId, uint256 amount) external nonReentrant whenNotPaused {
+        _vote(proposalId, amount, msg.sender);
+    }
+
+    /// @notice Casts an approve vote on behalf of a signer using an EIP-712 signature.
+    /// @dev The signer's voting power is locked. Anyone can submit the transaction.
+    /// @param proposalId Proposal id (must be in `Voting` state).
+    /// @param amount Voting weight to lock.
+    /// @param nonce Expected nonce (must equal `nonces(signer)`).
+    /// @param deadline Signature expiry timestamp.
+    /// @param signature ECDSA signature over the typed `Vote` data (see `hashVote`).
+    function voteFor(uint256 proposalId, uint256 amount, uint256 nonce, uint256 deadline, bytes calldata signature)
+        external
+        nonReentrant
+        whenNotPaused
+    {
+        address signer = _verifyAndConsumeMetaTx(hashVote(proposalId, amount, nonce, deadline), nonce, deadline, signature);
+        _vote(proposalId, amount, signer);
+    }
+
+    /// @dev Casts (or adds to) an approve vote for `voter`, locking `amount` of voting power.
+    function _vote(uint256 proposalId, uint256 amount, address voter) internal {
         Proposal storage proposal = proposals[proposalId];
         if (proposal.state != ProposalState.Voting) revert ProposalNotVoting(proposalId);
         if (amount == 0) revert ZeroAmount();
 
-        voteToken.lock(msg.sender, amount);
+        voteToken.lock(voter, amount);
 
-        if (votes[proposalId][msg.sender] == 0) {
+        if (votes[proposalId][voter] == 0) {
             proposal.voterCount += 1;
         }
-        if (!hasVoted[proposalId][msg.sender]) {
-            hasVoted[proposalId][msg.sender] = true;
-            _participated[msg.sender].push(proposalId);
+        if (!hasVoted[proposalId][voter]) {
+            hasVoted[proposalId][voter] = true;
+            _participated[voter].push(proposalId);
         }
-        votes[proposalId][msg.sender] += amount;
+        votes[proposalId][voter] += amount;
         proposal.totalVotes += amount;
 
-        emit Voted(proposalId, msg.sender, amount, votes[proposalId][msg.sender]);
+        emit Voted(proposalId, voter, amount, votes[proposalId][voter]);
     }
 
     /// @notice Withdraws part/all of the caller's vote, unlocking `amount` of voting power.
@@ -172,22 +217,54 @@ contract ResearchHubVoting is Initializable, OwnableUpgradeable, UUPSUpgradeable
     /// @param proposalId Proposal id (must exist).
     /// @param amount Amount to withdraw (must be > 0 and <= caller's current vote).
     function withdrawVote(uint256 proposalId, uint256 amount) external nonReentrant whenNotPaused {
+        _withdrawVote(proposalId, amount, msg.sender);
+    }
+
+    /// @notice Withdraws part/all of a signer's vote on their behalf using an EIP-712 signature.
+    /// @dev Unlocks the signer's voting power. Anyone can submit the transaction. Signed
+    ///      authorization prevents third parties from retracting someone's vote during voting.
+    /// @param proposalId Proposal id (must exist).
+    /// @param amount Amount to withdraw.
+    /// @param nonce Expected nonce (must equal `nonces(signer)`).
+    /// @param deadline Signature expiry timestamp.
+    /// @param signature ECDSA signature over the typed `WithdrawVote` data (see `hashWithdrawVote`).
+    function withdrawVoteFor(uint256 proposalId, uint256 amount, uint256 nonce, uint256 deadline, bytes calldata signature)
+        external
+        nonReentrant
+        whenNotPaused
+    {
+        address signer = _verifyAndConsumeMetaTx(hashWithdrawVote(proposalId, amount, nonce, deadline), nonce, deadline, signature);
+        _withdrawVote(proposalId, amount, signer);
+    }
+
+    /// @dev Withdraws part/all of `voter`'s vote, unlocking `amount` of voting power.
+    function _withdrawVote(uint256 proposalId, uint256 amount, address voter) internal {
         Proposal storage proposal = proposals[proposalId];
         if (proposal.state == ProposalState.NonExistent) revert ProposalNotExist(proposalId);
         if (amount == 0) revert ZeroAmount();
-        uint256 voted = votes[proposalId][msg.sender];
-        if (amount > voted) revert ExceedsVotedAmount(proposalId, msg.sender, voted, amount);
+        uint256 voted = votes[proposalId][voter];
+        if (amount > voted) revert ExceedsVotedAmount(proposalId, voter, voted, amount);
 
-        voteToken.unlock(msg.sender, amount);
+        voteToken.unlock(voter, amount);
 
         uint256 remaining = voted - amount;
-        votes[proposalId][msg.sender] = remaining;
+        votes[proposalId][voter] = remaining;
         proposal.totalVotes -= amount;
         if (remaining == 0) {
             proposal.voterCount -= 1;
         }
 
-        emit VoteWithdrawn(proposalId, msg.sender, amount, remaining);
+        emit VoteWithdrawn(proposalId, voter, amount, remaining);
+    }
+
+    /// @notice Returns the EIP-712 digest to sign for `voteFor`.
+    function hashVote(uint256 proposalId, uint256 amount, uint256 nonce, uint256 deadline) public view returns (bytes32) {
+        return _hashTypedDataV4(keccak256(abi.encode(VOTE_TYPE_HASH, proposalId, amount, nonce, deadline)));
+    }
+
+    /// @notice Returns the EIP-712 digest to sign for `withdrawVoteFor`.
+    function hashWithdrawVote(uint256 proposalId, uint256 amount, uint256 nonce, uint256 deadline) public view returns (bytes32) {
+        return _hashTypedDataV4(keccak256(abi.encode(WITHDRAW_VOTE_TYPE_HASH, proposalId, amount, nonce, deadline)));
     }
 
     /// @notice Ends voting for a proposal. Only the proposal's issuer can call.

--- a/src/ResearchHubVoting.sol
+++ b/src/ResearchHubVoting.sol
@@ -211,9 +211,26 @@ contract ResearchHubVoting is Initializable, OwnableUpgradeable, UUPSUpgradeable
         return votes[proposalId][voter];
     }
 
-    /// @notice Returns the list of distinct proposal ids `voter` has participated in.
-    function getParticipatedProposals(address voter) external view returns (uint256[] memory) {
-        return _participated[voter];
+    /// @notice Returns the distinct proposals `voter` has participated in, along with each
+    ///         proposal's current record and the voter's current vote amount on it.
+    /// @param voter Voter address.
+    /// @return proposalIds Distinct proposal ids the voter participated in.
+    /// @return proposalInfos Current proposal records, aligned with `proposalIds`.
+    /// @return votedAmounts Voter's current vote amount per proposal, aligned with `proposalIds`.
+    function getParticipatedProposals(address voter)
+        external
+        view
+        returns (uint256[] memory proposalIds, Proposal[] memory proposalInfos, uint256[] memory votedAmounts)
+    {
+        proposalIds = _participated[voter];
+        uint256 len = proposalIds.length;
+        proposalInfos = new Proposal[](len);
+        votedAmounts = new uint256[](len);
+        for (uint256 i; i < len; i++) {
+            uint256 pid = proposalIds[i];
+            proposalInfos[i] = proposals[pid];
+            votedAmounts[i] = votes[pid][voter];
+        }
     }
 
     /// @notice Returns how many participation entries `voter` has.

--- a/src/StakeToken.sol
+++ b/src/StakeToken.sol
@@ -31,6 +31,11 @@ contract StakeToken is Initializable, ERC20Upgradeable, OwnableUpgradeable, UUPS
     mapping(address => bool) public lockers;
     mapping(address => Lock[]) private _locks;
 
+    // Releasable balance locks (no expiry): locker => user => amount locked by that locker for the user.
+    mapping(address => mapping(address => uint256)) public lockedBalances;
+    // user => total amount locked across all lockers (used by getAvailableBalance).
+    mapping(address => uint256) public lockedTotals;
+
     event Stake(address staker, uint256 amount);
     event UnStake(address unstaker, uint256 amount);
     event Withdraw(address withdrawer, uint256 amount);
@@ -38,6 +43,8 @@ contract StakeToken is Initializable, ERC20Upgradeable, OwnableUpgradeable, UUPS
     event LockerRoleGranted(address indexed user);
     event LockerRoleRevoked(address indexed user);
     event Locked(address indexed user, uint256 amount, uint256 expiry);
+    event BalanceLocked(address indexed locker, address indexed user, uint256 amount);
+    event BalanceUnlocked(address indexed locker, address indexed user, uint256 amount);
 
     error InsufficientAvailableBalance(address user, uint256 available, uint256 required);
     error TooManyActiveLocks(address user, uint256 count);
@@ -152,8 +159,29 @@ contract StakeToken is Initializable, ERC20Upgradeable, OwnableUpgradeable, UUPS
         emit Locked(user, amount, expiry);
     }
 
+    /// @notice Locks `amount` of `user`'s balance with no expiry; releasable any time via `unlock`.
+    /// @dev Only callable by a locker. Accounting is scoped to the calling locker so it can only
+    ///      release what it locked. The locked amount counts against `getAvailableBalance`.
+    function lock(address user, uint256 amount) external onlyLocker whenNotPaused {
+        require(amount > 0, "amount is zero");
+        require(getAvailableBalance(user) >= amount, "insufficient available");
+        lockedBalances[msg.sender][user] += amount;
+        lockedTotals[user] += amount;
+        emit BalanceLocked(msg.sender, user, amount);
+    }
+
+    /// @notice Releases `amount` previously locked by the caller for `user`.
+    /// @dev No role check needed: a caller can only release locks it created (scoped accounting).
+    function unlock(address user, uint256 amount) external whenNotPaused {
+        require(amount > 0, "amount is zero");
+        require(lockedBalances[msg.sender][user] >= amount, "exceeds locked");
+        lockedBalances[msg.sender][user] -= amount;
+        lockedTotals[user] -= amount;
+        emit BalanceUnlocked(msg.sender, user, amount);
+    }
+
     function getAvailableBalance(address user) public view returns (uint256) {
-        uint256 locked = _totalActiveLocks(user);
+        uint256 locked = _totalActiveLocks(user) + lockedTotals[user];
         uint256 balance = balanceOf(user);
         if (locked >= balance) return 0;
         return balance - locked;

--- a/test/ResearchHubVoting.t.sol
+++ b/test/ResearchHubVoting.t.sol
@@ -157,10 +157,20 @@ contract ResearchHubVotingTest is Test {
         assertEq(stakeToken.getAvailableBalance(voter1), STAKE_AMOUNT - 10 ether);
         assertEq(stakeToken.lockedBalances(address(voting), voter1), 10 ether);
 
-        // participation recorded once
-        uint256[] memory participated = voting.getParticipatedProposals(voter1);
+        // participation recorded once, with proposal info and the voter's amount
+        (
+            uint256[] memory participated,
+            ResearchHubVoting.Proposal[] memory infos,
+            uint256[] memory amounts
+        ) = voting.getParticipatedProposals(voter1);
         assertEq(participated.length, 1);
         assertEq(participated[0], PROPOSAL_ID);
+        assertEq(infos.length, 1);
+        assertEq(infos[0].issuer, issuer);
+        assertEq(infos[0].totalVotes, 10 ether);
+        assertEq(uint8(infos[0].state), uint8(ResearchHubVoting.ProposalState.Voting));
+        assertEq(amounts.length, 1);
+        assertEq(amounts[0], 10 ether);
     }
 
     function testVoteAccumulatesSingleParticipation() public {
@@ -189,6 +199,42 @@ contract ResearchHubVotingTest is Test {
         ResearchHubVoting.Proposal memory p = voting.getProposal(PROPOSAL_ID);
         assertEq(p.voterCount, 2);
         assertEq(p.totalVotes, 30 ether);
+    }
+
+    function testGetParticipatedProposalsAcrossMultiple() public {
+        uint256 pid2 = 2;
+        vm.startPrank(issuer);
+        voting.createProposal(PROPOSAL_ID);
+        voting.createProposal(pid2);
+        vm.stopPrank();
+
+        vm.startPrank(voter1);
+        voting.vote(PROPOSAL_ID, 10 ether);
+        voting.vote(pid2, 25 ether);
+        vm.stopPrank();
+
+        // end the second proposal to vary state
+        vm.prank(issuer);
+        voting.endVoting(pid2);
+
+        (
+            uint256[] memory ids,
+            ResearchHubVoting.Proposal[] memory infos,
+            uint256[] memory amounts
+        ) = voting.getParticipatedProposals(voter1);
+
+        assertEq(ids.length, 2);
+        assertEq(infos.length, 2);
+        assertEq(amounts.length, 2);
+
+        assertEq(ids[0], PROPOSAL_ID);
+        assertEq(amounts[0], 10 ether);
+        assertEq(uint8(infos[0].state), uint8(ResearchHubVoting.ProposalState.Voting));
+
+        assertEq(ids[1], pid2);
+        assertEq(amounts[1], 25 ether);
+        assertEq(infos[1].totalVotes, 25 ether);
+        assertEq(uint8(infos[1].state), uint8(ResearchHubVoting.ProposalState.VotingEnded));
     }
 
     function testVoteZeroAmountReverts() public {

--- a/test/ResearchHubVoting.t.sol
+++ b/test/ResearchHubVoting.t.sol
@@ -85,6 +85,46 @@ contract ResearchHubVotingTest is Test {
         voting.createProposal(PROPOSAL_ID);
     }
 
+    function testBatchCreateProposal() public {
+        uint256[] memory ids = new uint256[](3);
+        ids[0] = 10;
+        ids[1] = 11;
+        ids[2] = 12;
+
+        vm.prank(issuer);
+        voting.batchCreateProposal(ids);
+
+        for (uint256 i; i < ids.length; i++) {
+            ResearchHubVoting.Proposal memory p = voting.getProposal(ids[i]);
+            assertEq(p.issuer, issuer);
+            assertEq(uint8(p.state), uint8(ResearchHubVoting.ProposalState.Voting));
+        }
+    }
+
+    function testBatchCreateProposalUnauthorizedReverts() public {
+        address stranger = vm.addr(0xBEEF);
+        uint256[] memory ids = new uint256[](1);
+        ids[0] = 10;
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSelector(ResearchHubVoting.NotAuthorizedIssuer.selector, stranger));
+        voting.batchCreateProposal(ids);
+    }
+
+    function testBatchCreateProposalRevertsAtomicallyOnDuplicate() public {
+        _createProposal(); // PROPOSAL_ID = 1 already exists
+
+        uint256[] memory ids = new uint256[](2);
+        ids[0] = 10;
+        ids[1] = PROPOSAL_ID; // duplicate -> whole batch reverts
+
+        vm.prank(issuer);
+        vm.expectRevert(abi.encodeWithSelector(ResearchHubVoting.ProposalAlreadyExists.selector, PROPOSAL_ID));
+        voting.batchCreateProposal(ids);
+
+        // none of the new ids were created
+        assertEq(uint8(voting.getProposal(10).state), uint8(ResearchHubVoting.ProposalState.NonExistent));
+    }
+
     // ========== Issuer authorization ==========
 
     function testCreateProposalUnauthorizedReverts() public {

--- a/test/ResearchHubVoting.t.sol
+++ b/test/ResearchHubVoting.t.sol
@@ -1,0 +1,366 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.25;
+
+import "../src/ResearchHubVoting.sol";
+import "../src/StakeToken.sol";
+import "@openzeppelin/contracts/proxy/ERC1967/ERC1967Proxy.sol";
+import {Test} from "forge-std/Test.sol";
+
+contract ResearchHubVotingTest is Test {
+    address owner = vm.addr(0x1);
+    address issuer = vm.addr(0x2);
+    address voter1 = vm.addr(0x10);
+    address voter2 = vm.addr(0x11);
+
+    StakeToken stakeToken;
+    ResearchHubVoting voting;
+
+    uint256 constant STAKE_AMOUNT = 100 ether;
+    uint256 constant PROPOSAL_ID = 1;
+
+    function setUp() public {
+        vm.deal(voter1, 1000 ether);
+        vm.deal(voter2, 1000 ether);
+
+        vm.startPrank(owner);
+        StakeToken stakeImpl = new StakeToken();
+        stakeToken = StakeToken(payable(address(new ERC1967Proxy(
+            address(stakeImpl),
+            abi.encodeCall(StakeToken.initialize, ("Staked SOSO", "sSOSO", address(0), 3600 * 24 * 7, owner))
+        ))));
+
+        ResearchHubVoting votingImpl = new ResearchHubVoting();
+        voting = ResearchHubVoting(address(new ERC1967Proxy(
+            address(votingImpl),
+            abi.encodeCall(ResearchHubVoting.initialize, (address(stakeToken), owner))
+        )));
+
+        stakeToken.grantLockerRole(address(voting));
+        voting.grantIssuerRole(issuer);
+        vm.stopPrank();
+
+        vm.prank(voter1);
+        stakeToken.stake{value: STAKE_AMOUNT}(STAKE_AMOUNT);
+        vm.prank(voter2);
+        stakeToken.stake{value: STAKE_AMOUNT}(STAKE_AMOUNT);
+    }
+
+    function _createProposal() internal {
+        vm.prank(issuer);
+        voting.createProposal(PROPOSAL_ID);
+    }
+
+    // ========== Initialization ==========
+
+    function testInitializeState() public view {
+        assertEq(address(voting.voteToken()), address(stakeToken));
+        assertEq(voting.owner(), owner);
+    }
+
+    function testInitializeZeroVoteToken() public {
+        ResearchHubVoting impl = new ResearchHubVoting();
+        vm.expectRevert(ResearchHubVoting.ZeroAddress.selector);
+        new ERC1967Proxy(address(impl), abi.encodeCall(ResearchHubVoting.initialize, (address(0), owner)));
+    }
+
+    // ========== Proposal Creation ==========
+
+    function testCreateProposal() public {
+        vm.expectEmit(true, true, false, false);
+        emit ResearchHubVoting.ProposalCreated(PROPOSAL_ID, issuer);
+
+        _createProposal();
+
+        ResearchHubVoting.Proposal memory p = voting.getProposal(PROPOSAL_ID);
+        assertEq(p.issuer, issuer);
+        assertEq(uint8(p.state), uint8(ResearchHubVoting.ProposalState.Voting));
+        assertEq(p.voterCount, 0);
+        assertEq(p.totalVotes, 0);
+    }
+
+    function testCreateProposalDuplicateReverts() public {
+        _createProposal();
+        vm.prank(issuer);
+        vm.expectRevert(abi.encodeWithSelector(ResearchHubVoting.ProposalAlreadyExists.selector, PROPOSAL_ID));
+        voting.createProposal(PROPOSAL_ID);
+    }
+
+    // ========== Issuer authorization ==========
+
+    function testCreateProposalUnauthorizedReverts() public {
+        address stranger = vm.addr(0xBEEF);
+        vm.prank(stranger);
+        vm.expectRevert(abi.encodeWithSelector(ResearchHubVoting.NotAuthorizedIssuer.selector, stranger));
+        voting.createProposal(PROPOSAL_ID);
+    }
+
+    function testGrantIssuerRole() public {
+        address newIssuer = vm.addr(0xC0FFEE);
+        assertFalse(voting.issuers(newIssuer));
+
+        vm.expectEmit(true, false, false, false);
+        emit ResearchHubVoting.IssuerRoleGranted(newIssuer);
+        vm.prank(owner);
+        voting.grantIssuerRole(newIssuer);
+
+        assertTrue(voting.issuers(newIssuer));
+
+        vm.prank(newIssuer);
+        voting.createProposal(PROPOSAL_ID);
+        assertEq(voting.getProposal(PROPOSAL_ID).issuer, newIssuer);
+    }
+
+    function testRevokeIssuerRole() public {
+        assertTrue(voting.issuers(issuer));
+
+        vm.expectEmit(true, false, false, false);
+        emit ResearchHubVoting.IssuerRoleRevoked(issuer);
+        vm.prank(owner);
+        voting.revokeIssuerRole(issuer);
+
+        assertFalse(voting.issuers(issuer));
+
+        vm.prank(issuer);
+        vm.expectRevert(abi.encodeWithSelector(ResearchHubVoting.NotAuthorizedIssuer.selector, issuer));
+        voting.createProposal(PROPOSAL_ID);
+    }
+
+    function testGrantIssuerRoleOnlyOwner() public {
+        vm.prank(issuer);
+        vm.expectRevert();
+        voting.grantIssuerRole(vm.addr(0xD00D));
+    }
+
+    function testGrantIssuerRoleZeroAddressReverts() public {
+        vm.prank(owner);
+        vm.expectRevert(ResearchHubVoting.ZeroAddress.selector);
+        voting.grantIssuerRole(address(0));
+    }
+
+    // ========== Voting ==========
+
+    function testVoteLocksAndCounts() public {
+        _createProposal();
+
+        vm.expectEmit(true, true, false, true);
+        emit ResearchHubVoting.Voted(PROPOSAL_ID, voter1, 10 ether, 10 ether);
+
+        vm.prank(voter1);
+        voting.vote(PROPOSAL_ID, 10 ether);
+
+        ResearchHubVoting.Proposal memory p = voting.getProposal(PROPOSAL_ID);
+        assertEq(p.voterCount, 1);
+        assertEq(p.totalVotes, 10 ether);
+        assertEq(voting.getVotes(PROPOSAL_ID, voter1), 10 ether);
+
+        // sSOSO locked: available balance reduced, locked recorded against the voting contract.
+        assertEq(stakeToken.getAvailableBalance(voter1), STAKE_AMOUNT - 10 ether);
+        assertEq(stakeToken.lockedBalances(address(voting), voter1), 10 ether);
+
+        // participation recorded once
+        uint256[] memory participated = voting.getParticipatedProposals(voter1);
+        assertEq(participated.length, 1);
+        assertEq(participated[0], PROPOSAL_ID);
+    }
+
+    function testVoteAccumulatesSingleParticipation() public {
+        _createProposal();
+
+        vm.startPrank(voter1);
+        voting.vote(PROPOSAL_ID, 10 ether);
+        voting.vote(PROPOSAL_ID, 5 ether);
+        vm.stopPrank();
+
+        ResearchHubVoting.Proposal memory p = voting.getProposal(PROPOSAL_ID);
+        assertEq(p.voterCount, 1);
+        assertEq(p.totalVotes, 15 ether);
+        assertEq(voting.getVotes(PROPOSAL_ID, voter1), 15 ether);
+        assertEq(voting.getParticipatedCount(voter1), 1);
+    }
+
+    function testVoteMultipleVoters() public {
+        _createProposal();
+
+        vm.prank(voter1);
+        voting.vote(PROPOSAL_ID, 10 ether);
+        vm.prank(voter2);
+        voting.vote(PROPOSAL_ID, 20 ether);
+
+        ResearchHubVoting.Proposal memory p = voting.getProposal(PROPOSAL_ID);
+        assertEq(p.voterCount, 2);
+        assertEq(p.totalVotes, 30 ether);
+    }
+
+    function testVoteZeroAmountReverts() public {
+        _createProposal();
+        vm.prank(voter1);
+        vm.expectRevert(ResearchHubVoting.ZeroAmount.selector);
+        voting.vote(PROPOSAL_ID, 0);
+    }
+
+    function testVoteNonExistentProposalReverts() public {
+        vm.prank(voter1);
+        vm.expectRevert(abi.encodeWithSelector(ResearchHubVoting.ProposalNotVoting.selector, PROPOSAL_ID));
+        voting.vote(PROPOSAL_ID, 10 ether);
+    }
+
+    function testVoteExceedingAvailableReverts() public {
+        _createProposal();
+        vm.prank(voter1);
+        vm.expectRevert("insufficient available");
+        voting.vote(PROPOSAL_ID, STAKE_AMOUNT + 1);
+    }
+
+    function testLockedVotesBlockUnstake() public {
+        _createProposal();
+        vm.prank(voter1);
+        voting.vote(PROPOSAL_ID, 90 ether);
+
+        vm.prank(voter1);
+        vm.expectRevert(
+            abi.encodeWithSelector(StakeToken.InsufficientAvailableBalance.selector, voter1, 10 ether, 50 ether)
+        );
+        stakeToken.unstake(50 ether);
+    }
+
+    // ========== Withdraw (unlock) during voting ==========
+
+    function testWithdrawPartialDuringVoting() public {
+        _createProposal();
+        vm.prank(voter1);
+        voting.vote(PROPOSAL_ID, 10 ether);
+
+        vm.expectEmit(true, true, false, true);
+        emit ResearchHubVoting.VoteWithdrawn(PROPOSAL_ID, voter1, 4 ether, 6 ether);
+
+        vm.prank(voter1);
+        voting.withdrawVote(PROPOSAL_ID, 4 ether);
+
+        ResearchHubVoting.Proposal memory p = voting.getProposal(PROPOSAL_ID);
+        assertEq(p.voterCount, 1);
+        assertEq(p.totalVotes, 6 ether);
+        assertEq(voting.getVotes(PROPOSAL_ID, voter1), 6 ether);
+        assertEq(stakeToken.getAvailableBalance(voter1), STAKE_AMOUNT - 6 ether);
+    }
+
+    function testWithdrawFullDecrementsVoterCount() public {
+        _createProposal();
+        vm.prank(voter1);
+        voting.vote(PROPOSAL_ID, 10 ether);
+
+        vm.prank(voter1);
+        voting.withdrawVote(PROPOSAL_ID, 10 ether);
+
+        ResearchHubVoting.Proposal memory p = voting.getProposal(PROPOSAL_ID);
+        assertEq(p.voterCount, 0);
+        assertEq(p.totalVotes, 0);
+        assertEq(voting.getVotes(PROPOSAL_ID, voter1), 0);
+        assertEq(stakeToken.getAvailableBalance(voter1), STAKE_AMOUNT);
+    }
+
+    function testWithdrawExceedsVotedReverts() public {
+        _createProposal();
+        vm.prank(voter1);
+        voting.vote(PROPOSAL_ID, 10 ether);
+
+        vm.prank(voter1);
+        vm.expectRevert(
+            abi.encodeWithSelector(ResearchHubVoting.ExceedsVotedAmount.selector, PROPOSAL_ID, voter1, 10 ether, 11 ether)
+        );
+        voting.withdrawVote(PROPOSAL_ID, 11 ether);
+    }
+
+    function testReVoteAfterFullWithdrawNoDuplicateParticipation() public {
+        _createProposal();
+        vm.startPrank(voter1);
+        voting.vote(PROPOSAL_ID, 10 ether);
+        voting.withdrawVote(PROPOSAL_ID, 10 ether);
+        voting.vote(PROPOSAL_ID, 5 ether);
+        vm.stopPrank();
+
+        // hasVoted gates the participation push: recorded once even after withdraw + re-vote.
+        assertEq(voting.getParticipatedCount(voter1), 1);
+        assertTrue(voting.hasVoted(PROPOSAL_ID, voter1));
+        ResearchHubVoting.Proposal memory p = voting.getProposal(PROPOSAL_ID);
+        assertEq(p.voterCount, 1);
+        assertEq(p.totalVotes, 5 ether);
+    }
+
+    // ========== Ending voting ==========
+
+    function testEndVotingOnlyIssuer() public {
+        _createProposal();
+        vm.prank(voter1);
+        vm.expectRevert(abi.encodeWithSelector(ResearchHubVoting.NotIssuer.selector, PROPOSAL_ID));
+        voting.endVoting(PROPOSAL_ID);
+    }
+
+    function testEndVotingEmitsAndBlocksVote() public {
+        _createProposal();
+        vm.prank(voter1);
+        voting.vote(PROPOSAL_ID, 10 ether);
+
+        vm.expectEmit(true, true, false, true);
+        emit ResearchHubVoting.VotingEnded(PROPOSAL_ID, issuer, 10 ether, 1);
+
+        vm.prank(issuer);
+        voting.endVoting(PROPOSAL_ID);
+
+        ResearchHubVoting.Proposal memory p = voting.getProposal(PROPOSAL_ID);
+        assertEq(uint8(p.state), uint8(ResearchHubVoting.ProposalState.VotingEnded));
+
+        vm.prank(voter2);
+        vm.expectRevert(abi.encodeWithSelector(ResearchHubVoting.ProposalNotVoting.selector, PROPOSAL_ID));
+        voting.vote(PROPOSAL_ID, 5 ether);
+    }
+
+    function testEndVotingTwiceReverts() public {
+        _createProposal();
+        vm.startPrank(issuer);
+        voting.endVoting(PROPOSAL_ID);
+        vm.expectRevert(abi.encodeWithSelector(ResearchHubVoting.ProposalNotVoting.selector, PROPOSAL_ID));
+        voting.endVoting(PROPOSAL_ID);
+        vm.stopPrank();
+    }
+
+    function testWithdrawAllowedAfterVotingEnded() public {
+        _createProposal();
+        vm.prank(voter1);
+        voting.vote(PROPOSAL_ID, 10 ether);
+
+        vm.prank(issuer);
+        voting.endVoting(PROPOSAL_ID);
+
+        // After end, voter can only withdraw (unlock).
+        vm.prank(voter1);
+        voting.withdrawVote(PROPOSAL_ID, 10 ether);
+
+        assertEq(stakeToken.getAvailableBalance(voter1), STAKE_AMOUNT);
+        assertEq(voting.getVotes(PROPOSAL_ID, voter1), 0);
+
+        // and can then unstake the freed balance
+        vm.prank(voter1);
+        stakeToken.unstake(10 ether);
+        assertEq(stakeToken.balanceOf(voter1), STAKE_AMOUNT - 10 ether);
+    }
+
+    // ========== Lock/unlock event timing for off-chain weight ==========
+
+    function testLockUnlockEmitsTokenEventsForWeight() public {
+        _createProposal();
+
+        vm.expectEmit(true, true, false, true);
+        emit StakeToken.BalanceLocked(address(voting), voter1, 10 ether);
+        vm.prank(voter1);
+        voting.vote(PROPOSAL_ID, 10 ether);
+
+        vm.warp(block.timestamp + 3 days);
+
+        vm.expectEmit(true, true, false, true);
+        emit StakeToken.BalanceUnlocked(address(voting), voter1, 10 ether);
+        vm.prank(voter1);
+        voting.withdrawVote(PROPOSAL_ID, 10 ether);
+    }
+
+    receive() external payable {}
+}

--- a/test/ResearchHubVoting.t.sol
+++ b/test/ResearchHubVoting.t.sol
@@ -408,5 +408,94 @@ contract ResearchHubVotingTest is Test {
         voting.withdrawVote(PROPOSAL_ID, 10 ether);
     }
 
+    // ========== EIP-712 voteFor / withdrawVoteFor ==========
+
+    uint256 constant VOTER1_PK = 0x10; // matches voter1 = vm.addr(0x10)
+
+    function _signVote(uint256 pk, uint256 pid, uint256 amount, uint256 nonce, uint256 deadline)
+        internal
+        returns (bytes memory)
+    {
+        bytes32 digest = voting.hashVote(pid, amount, nonce, deadline);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function _signWithdraw(uint256 pk, uint256 pid, uint256 amount, uint256 nonce, uint256 deadline)
+        internal
+        returns (bytes memory)
+    {
+        bytes32 digest = voting.hashWithdrawVote(pid, amount, nonce, deadline);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(pk, digest);
+        return abi.encodePacked(r, s, v);
+    }
+
+    function testVoteForLocksAndIncrementsNonce() public {
+        _createProposal();
+        uint256 deadline = block.timestamp + 1 hours;
+        uint256 nonce = voting.nonces(voter1);
+        bytes memory sig = _signVote(VOTER1_PK, PROPOSAL_ID, 10 ether, nonce, deadline);
+
+        // a relayer (voter2) submits voter1's signed vote
+        vm.prank(voter2);
+        voting.voteFor(PROPOSAL_ID, 10 ether, nonce, deadline, sig);
+
+        assertEq(voting.getVotes(PROPOSAL_ID, voter1), 10 ether);
+        assertEq(voting.getProposal(PROPOSAL_ID).totalVotes, 10 ether);
+        assertEq(voting.getProposal(PROPOSAL_ID).voterCount, 1);
+        assertEq(stakeToken.lockedBalances(address(voting), voter1), 10 ether);
+        assertEq(voting.nonces(voter1), nonce + 1);
+    }
+
+    function testWithdrawVoteForUnlocks() public {
+        _createProposal();
+        vm.prank(voter1);
+        voting.vote(PROPOSAL_ID, 10 ether);
+
+        uint256 deadline = block.timestamp + 1 hours;
+        uint256 nonce = voting.nonces(voter1);
+        bytes memory sig = _signWithdraw(VOTER1_PK, PROPOSAL_ID, 4 ether, nonce, deadline);
+
+        vm.prank(voter2);
+        voting.withdrawVoteFor(PROPOSAL_ID, 4 ether, nonce, deadline, sig);
+
+        assertEq(voting.getVotes(PROPOSAL_ID, voter1), 6 ether);
+        assertEq(stakeToken.getAvailableBalance(voter1), STAKE_AMOUNT - 6 ether);
+        assertEq(voting.nonces(voter1), nonce + 1);
+    }
+
+    function testVoteForExpiredSignatureReverts() public {
+        _createProposal();
+        vm.warp(1000);
+        uint256 deadline = block.timestamp - 1;
+        uint256 nonce = voting.nonces(voter1);
+        bytes memory sig = _signVote(VOTER1_PK, PROPOSAL_ID, 10 ether, nonce, deadline);
+        vm.expectRevert(abi.encodeWithSelector(ResearchHubVoting.ExpiredSignature.selector, deadline));
+        voting.voteFor(PROPOSAL_ID, 10 ether, nonce, deadline, sig);
+    }
+
+    function testVoteForInvalidNonceReverts() public {
+        _createProposal();
+        uint256 deadline = block.timestamp + 1 hours;
+        uint256 expected = voting.nonces(voter1);
+        uint256 wrongNonce = expected + 1;
+        bytes memory sig = _signVote(VOTER1_PK, PROPOSAL_ID, 10 ether, wrongNonce, deadline);
+        vm.expectRevert(abi.encodeWithSelector(ResearchHubVoting.InvalidNonce.selector, voter1, expected, wrongNonce));
+        voting.voteFor(PROPOSAL_ID, 10 ether, wrongNonce, deadline, sig);
+    }
+
+    function testVoteForReplayReverts() public {
+        _createProposal();
+        uint256 deadline = block.timestamp + 1 hours;
+        uint256 nonce = voting.nonces(voter1);
+        bytes memory sig = _signVote(VOTER1_PK, PROPOSAL_ID, 10 ether, nonce, deadline);
+
+        voting.voteFor(PROPOSAL_ID, 10 ether, nonce, deadline, sig);
+
+        // nonce consumed: replay now expects nonce+1
+        vm.expectRevert(abi.encodeWithSelector(ResearchHubVoting.InvalidNonce.selector, voter1, nonce + 1, nonce));
+        voting.voteFor(PROPOSAL_ID, 10 ether, nonce, deadline, sig);
+    }
+
     receive() external payable {}
 }

--- a/test/ResearchHubVoting.t.sol
+++ b/test/ResearchHubVoting.t.sol
@@ -277,6 +277,52 @@ contract ResearchHubVotingTest is Test {
         assertEq(uint8(infos[1].state), uint8(ResearchHubVoting.ProposalState.VotingEnded));
     }
 
+    function testGetParticipatedProposalsPaginated() public {
+        // voter1 participates in 3 proposals
+        uint256[] memory ids = new uint256[](3);
+        ids[0] = 10; ids[1] = 11; ids[2] = 12;
+        vm.prank(issuer);
+        voting.batchCreateProposal(ids);
+
+        vm.startPrank(voter1);
+        voting.vote(10, 1 ether);
+        voting.vote(11, 2 ether);
+        voting.vote(12, 3 ether);
+        vm.stopPrank();
+
+        // middle page [1, 2)
+        (
+            uint256[] memory pids,
+            ResearchHubVoting.Proposal[] memory infos,
+            uint256[] memory amounts
+        ) = voting.getParticipatedProposals(voter1, 1, 2);
+
+        assertEq(pids.length, 1);
+        assertEq(pids[0], 11);
+        assertEq(amounts[0], 2 ether);
+        assertEq(infos[0].totalVotes, 2 ether);
+
+        // full range matches the non-paginated getter
+        (uint256[] memory pidsFull,,) = voting.getParticipatedProposals(voter1, 0, 3);
+        assertEq(pidsFull.length, 3);
+        assertEq(pidsFull[0], 10);
+        assertEq(pidsFull[2], 12);
+    }
+
+    function testGetParticipatedProposalsPaginatedInvalidRange() public {
+        _createProposal();
+        vm.prank(voter1);
+        voting.vote(PROPOSAL_ID, 1 ether); // participation count = 1
+
+        // begin >= end
+        vm.expectRevert(abi.encodeWithSelector(ResearchHubVoting.InvalidRange.selector, 1, 1));
+        voting.getParticipatedProposals(voter1, 1, 1);
+
+        // end > length
+        vm.expectRevert(abi.encodeWithSelector(ResearchHubVoting.InvalidRange.selector, 0, 2));
+        voting.getParticipatedProposals(voter1, 0, 2);
+    }
+
     function testVoteZeroAmountReverts() public {
         _createProposal();
         vm.prank(voter1);

--- a/test/StakeTokenLock.t.sol
+++ b/test/StakeTokenLock.t.sol
@@ -289,5 +289,132 @@ contract StakeTokenLockTest is Test {
         stakeToken.lock(staker, lockAmount, block.timestamp + 1 hours);
     }
 
+    // ========== Releasable Balance Lock (lock/unlock by amount) ==========
+
+    function testBalanceLockBasic() public {
+        uint256 amount = 4 ether;
+
+        vm.prank(locker);
+        stakeToken.lock(staker, amount);
+
+        assertEq(stakeToken.lockedBalances(locker, staker), amount);
+        assertEq(stakeToken.lockedTotals(staker), amount);
+        assertEq(stakeToken.getAvailableBalance(staker), STAKE_AMOUNT - amount);
+    }
+
+    function testBalanceLockOnlyLocker() public {
+        vm.prank(staker);
+        vm.expectRevert("not locker");
+        stakeToken.lock(staker, 1 ether);
+    }
+
+    function testBalanceLockZeroAmount() public {
+        vm.prank(locker);
+        vm.expectRevert("amount is zero");
+        stakeToken.lock(staker, 0);
+    }
+
+    function testBalanceLockInsufficientAvailable() public {
+        vm.prank(locker);
+        vm.expectRevert("insufficient available");
+        stakeToken.lock(staker, STAKE_AMOUNT + 1);
+    }
+
+    function testBalanceLockUnlockFull() public {
+        uint256 amount = 6 ether;
+
+        vm.startPrank(locker);
+        stakeToken.lock(staker, amount);
+        stakeToken.unlock(staker, amount);
+        vm.stopPrank();
+
+        assertEq(stakeToken.lockedBalances(locker, staker), 0);
+        assertEq(stakeToken.lockedTotals(staker), 0);
+        assertEq(stakeToken.getAvailableBalance(staker), STAKE_AMOUNT);
+    }
+
+    function testBalanceUnlockPartial() public {
+        vm.startPrank(locker);
+        stakeToken.lock(staker, 6 ether);
+        stakeToken.unlock(staker, 2 ether);
+        vm.stopPrank();
+
+        assertEq(stakeToken.lockedBalances(locker, staker), 4 ether);
+        assertEq(stakeToken.lockedTotals(staker), 4 ether);
+        assertEq(stakeToken.getAvailableBalance(staker), STAKE_AMOUNT - 4 ether);
+    }
+
+    function testBalanceUnlockExceeds() public {
+        vm.startPrank(locker);
+        stakeToken.lock(staker, 3 ether);
+        vm.expectRevert("exceeds locked");
+        stakeToken.unlock(staker, 4 ether);
+        vm.stopPrank();
+    }
+
+    function testBalanceUnlockScopedToLocker() public {
+        address locker2 = vm.addr(0x77);
+        vm.prank(owner);
+        stakeToken.grantLockerRole(locker2);
+
+        vm.prank(locker);
+        stakeToken.lock(staker, 3 ether);
+
+        // locker2 never locked anything for staker, so it cannot unlock locker's lock.
+        vm.prank(locker2);
+        vm.expectRevert("exceeds locked");
+        stakeToken.unlock(staker, 3 ether);
+    }
+
+    function testBalanceLockCombinesWithExpiryLock() public {
+        vm.startPrank(locker);
+        stakeToken.lock(staker, 3 ether, block.timestamp + 1 hours); // expiry lock
+        stakeToken.lock(staker, 2 ether);                            // balance lock
+        vm.stopPrank();
+
+        assertEq(stakeToken.getAvailableBalance(staker), STAKE_AMOUNT - 5 ether);
+    }
+
+    function testBalanceLockBlocksTransfer() public {
+        vm.prank(locker);
+        stakeToken.lock(staker, 8 ether);
+
+        vm.prank(staker);
+        vm.expectRevert(
+            abi.encodeWithSelector(StakeToken.InsufficientAvailableBalance.selector, staker, 2 ether, 5 ether)
+        );
+        stakeToken.transfer(staker2, 5 ether);
+    }
+
+    function testBalanceLockBlocksUnstake() public {
+        vm.prank(locker);
+        stakeToken.lock(staker, 8 ether);
+
+        vm.prank(staker);
+        vm.expectRevert(
+            abi.encodeWithSelector(StakeToken.InsufficientAvailableBalance.selector, staker, 2 ether, 5 ether)
+        );
+        stakeToken.unstake(5 ether);
+    }
+
+    function testBalanceLockEmitsEvent() public {
+        vm.expectEmit(true, true, false, true);
+        emit StakeToken.BalanceLocked(locker, staker, 3 ether);
+
+        vm.prank(locker);
+        stakeToken.lock(staker, 3 ether);
+    }
+
+    function testBalanceUnlockEmitsEvent() public {
+        vm.prank(locker);
+        stakeToken.lock(staker, 3 ether);
+
+        vm.expectEmit(true, true, false, true);
+        emit StakeToken.BalanceUnlocked(locker, staker, 3 ether);
+
+        vm.prank(locker);
+        stakeToken.unlock(staker, 3 ether);
+    }
+
     receive() external payable {}
 }


### PR DESCRIPTION
Extend StakeToken with a releasable, locker-scoped balance lock and add the ResearchHubVoting contract for asset issuance voting.

StakeToken:
- New lock(user, amount) / unlock(user, amount) (overloaded alongside the existing expiry-based lock), tracked per locker via lockedBalances / lockedTotals and counted in getAvailableBalance.
- New BalanceLocked / BalanceUnlocked events for off-chain weight (amount x duration).
- ILockable interface extended with the new lock/unlock.

ResearchHubVoting (UUPS upgradeable, approve-only):
- Authorized issuers (grant/revokeIssuerRole) create proposals; anyone votes by locking sSOSO; voters can withdrawVote (unlock) any time; issuer ends voting, after which only withdrawals are allowed.
- Tracks per-proposal voterCount/totalVotes and per-voter participated proposals (deduped via hasVoted); emits Voted/VoteWithdrawn/VotingEnded.

Add ERC1967Proxy deploy script and Foundry tests (StakeToken balance-lock + full ResearchHubVoting suite).