### PR TITLE
Drop feeCollected check from addRebalanceRequest

### DIFF
--- a/src/AssetRebalancer.sol
+++ b/src/AssetRebalancer.sol
@@ -49,7 +49,6 @@ contract AssetRebalancer is AssetController, IAssetRebalancer {
         address swapAddress = factory.swaps(assetID);
         ISwap swap = ISwap(swapAddress);
         require(assetToken.totalSupply() > 0, "zero supply");
-        require(assetToken.feeCollected(), "has fee not collect");
         require(assetToken.hasRole(assetToken.REBALANCER_ROLE(), address(this)), "not a rebalancer");
         require(assetToken.rebalancing() == true, "not rebalancing");
         require(assetToken.issuing() == false, "is issuing");

--- a/test/AssetManager.t.sol
+++ b/test/AssetManager.t.sol
@@ -1110,6 +1110,28 @@ contract FundManagerTest is Test {
         assetToken.lockRebalance();
     }
 
+    function test_AddRebalanceRequest_AfterOneDayInWindow() public {
+        address assetTokenAddress = test_Mint();
+        AssetToken assetToken = AssetToken(assetTokenAddress);
+        uint256 assetID = assetToken.id();
+
+        vm.prank(owner);
+        rebalancer.startRebalance(assetID);
+        assertTrue(assetToken.rebalancing());
+
+        // fee collection is blocked while the window is open, so after a day
+        // feeCollected() turns false; the request must not be gated on it
+        vm.warp(vm.getBlockTimestamp() + 2 days);
+        assertTrue(!assetToken.feeCollected());
+
+        OrderInfo memory orderInfo = pmmQuoteRebalance(assetTokenAddress);
+        vm.startPrank(owner);
+        uint nonce = rebalancer.addRebalanceRequest(assetID, assetToken.getBasket(), orderInfo);
+        vm.stopPrank();
+        assertTrue(assetToken.rebalanceRequesting());
+        assertTrue(rebalancer.getRebalanceRequest(nonce).status == RequestStatus.PENDING);
+    }
+
     function test_StartRebalance_AccessControl() public {
         address assetTokenAddress = createAssetToken();
         AssetToken assetToken = AssetToken(assetTokenAddress);


### PR DESCRIPTION
## Summary
- Remove the `require(assetToken.feeCollected(), "has fee not collect")` guard from `AssetRebalancer.addRebalanceRequest`.
- `feeCollected()` is derived from `lastCollectTimestamp`, and `collectFeeTokenset` reverts while `rebalancing == true` — so once the rebalancing window stays open for more than 24 hours, `feeCollected()` turns false and every subsequent `addRebalanceRequest` reverts, deadlocking the rebalance flow (the only escape was endRebalance → collectFeeTokenset → startRebalance).
- The `feeCollected()` check on `startRebalance` is kept, so fees are still settled on the pre-rebalance basket before the window opens; no fee accrual can happen while the window is open, making the inner check redundant at best and a deadlock at worst.

## Test
- Added `test_AddRebalanceRequest_AfterOneDayInWindow`: opens the window, warps 2 days (asserts `feeCollected()` is false), then verifies `addRebalanceRequest` still succeeds with a PENDING request.
- `forge test --match-path test/AssetManager.t.sol`: 34/34 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)